### PR TITLE
docs: fix gene count in AnnData getting started tutorial

### DIFF
--- a/docs/notebooks/anndata_getting_started.ipynb
+++ b/docs/notebooks/anndata_getting_started.ipynb
@@ -147,7 +147,7 @@
    "id": "38597996-c348-4768-ac4a-98c056ba0e96",
    "metadata": {},
    "source": [
-    "This output tells us some general things about the data: its shape (2638 cells, 13714 genes) and which metadata fields and subfields it has. We will go through those one-by-one - let's start with the most important one:"
+    "This output tells us some general things about the data: its shape (2638 cells, 11505 genes) and which metadata fields and subfields it has. We will go through those one-by-one - let's start with the most important one:"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Correct free-text gene count in the AnnData getting started tutorial from 13714 to 11505 so it matches `adata` output for the tutorial’s processed PBMC3k dataset.
- Verified by loading the tutorial h5ad via the notebook’s `pooch.retrieve` + `anndata.read_h5ad` path and checking `adata.n_vars`.

## Test plan
- [ ] Confirm markdown after the first `adata` display says 2638 cells / 11505 genes
- [ ] Confirm notebook still contains stored outputs with `2638 × 11505` and no remaining `13714`