### PR TITLE
Point two tutorials at their moved documentation

### DIFF
--- a/tutorial-registry/tutorials/advanced-plotting/meta.yaml
+++ b/tutorial-registry/tutorials/advanced-plotting/meta.yaml
@@ -2,7 +2,7 @@ name: Advanced plotting
 description: |
   This tutorial explains how to customize matplotlib plots generated
   by scanpy or other scverse libraries.
-link: https://scanpy-tutorials.readthedocs.io/en/latest/plotting/advanced.html
+link: https://scanpy.readthedocs.io/en/stable/tutorials/plotting/advanced.html
 image: icon.png
 primary_category: Tips & Tricks
 order: 30

--- a/tutorial-registry/tutorials/concatenation-of-unimodal-data/meta.yaml
+++ b/tutorial-registry/tutorials/concatenation-of-unimodal-data/meta.yaml
@@ -3,7 +3,7 @@ description: |
   In this notebook we showcase how to perform concatenation, meaning to
   keep all sub elements of each object, and stack these elements in an
   ordered way.
-link: https://anndata.readthedocs.io/en/latest/concatenation.html
+link: https://anndata.readthedocs.io/en/stable/tutorials/concatenation.html
 image: icon.png
 primary_category: Data structures
 order: 30


### PR DESCRIPTION
Both links 404, so they show up as dead links on https://scverse.org/learn/.

Advanced plotting moved from `scanpy-tutorials.readthedocs.io` into the scanpy docs proper, and anndata's concatenation page moved under `tutorials/`; the other 21 links in the registry all resolve.
